### PR TITLE
新規登録、ログインフォームをReact Hook Formで管理

### DIFF
--- a/src/components/user/InputForm/InputForm.module.scss
+++ b/src/components/user/InputForm/InputForm.module.scss
@@ -9,6 +9,7 @@
 
   > input {
     border-radius: 10px;
+    border: none;
     padding: 0.3rem 0.6rem;
     margin-top: 0.3rem;
   }
@@ -16,4 +17,8 @@
 
 .errorMessage {
   height: 1rem;
+  font-size: 0.8rem;
+  color: rgb(255, 73, 73);
+  margin-bottom: 0.3rem;
+  margin-top: 0.2rem;
 }

--- a/src/components/user/InputForm/InputForm.tsx
+++ b/src/components/user/InputForm/InputForm.tsx
@@ -1,11 +1,11 @@
 import type { InputFormProps } from "@/types/userType";
 import styles from "./InputForm.module.scss";
 
-const InputForm = ({ label, name, type, error }: InputFormProps) => {
+const InputForm = ({ label, name, type, error, register }: InputFormProps) => {
   return (
     <div className={styles.inputContentGroup}>
       <label htmlFor={name}>{label}</label>
-      <input type={type} id={name} name={name} />
+      <input type={type} id={name} {...register} />
       <p className={styles.errorMessage}>{error}</p>
     </div>
   );

--- a/src/components/user/LoginFormContent/LoginFormContent.tsx
+++ b/src/components/user/LoginFormContent/LoginFormContent.tsx
@@ -1,19 +1,59 @@
+"use client";
+
 import Button from "@/components/utils/Button/Button";
+import { userLoginSchema } from "@/lib/validate";
+import type { LoginProps } from "@/types/userType";
+import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { type FieldErrors, useForm } from "react-hook-form";
 import FormTitle from "../FormTitle/FormTitle";
 import InputForm from "../InputForm/InputForm";
 import NavigationLink from "../NavigationLink/NavigationLink";
 import styles from "./LoginFormContent.module.scss";
 
 const LoginFormContent = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginProps>({ resolver: zodResolver(userLoginSchema) });
+
+  const onSubmit = (data: LoginProps) => {
+    console.log(data);
+  };
+
+  const onError = (error: FieldErrors<LoginProps>) => {
+    console.log(error);
+  };
   return (
     <>
-      <form action="" className={styles.loginFormContent}>
+      <form
+        action=""
+        onSubmit={handleSubmit(onSubmit, onError)}
+        className={styles.loginFormContent}
+      >
         <FormTitle title="ログイン" />
-        <InputForm label="メールアドレス" type="text" name="email" />
-        <InputForm label="パスワード" type="password" name="password" />
+        <InputForm
+          label="メールアドレス"
+          type="text"
+          name="email"
+          register={register("email")}
+          error={errors.email?.message}
+        />
+        <InputForm
+          label="パスワード"
+          type="password"
+          name="password"
+          register={register("password")}
+          error={errors.password?.message}
+        />
         <div className={styles.buttonGroup}>
-          <Button type="submit" label="ログイン" variant="primary" />
+          <Button
+            type="submit"
+            label="ログイン"
+            variant="primary"
+            disabled={isSubmitting}
+          />
           <Link href="/">
             <Button type="button" label="キャンセル" variant="secondary" />
           </Link>

--- a/src/components/user/RegisterFormContent/RegisterFormContent.tsx
+++ b/src/components/user/RegisterFormContent/RegisterFormContent.tsx
@@ -1,25 +1,73 @@
+"use client";
+
 import Button from "@/components/utils/Button/Button";
+import { userCreateSchema } from "@/lib/validate";
+import type { RegisterProps } from "@/types/userType";
+import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
+import { type FieldErrors, useForm } from "react-hook-form";
 import FormTitle from "../FormTitle/FormTitle";
 import InputForm from "../InputForm/InputForm";
 import NavigationLink from "../NavigationLink/NavigationLink";
 import styles from "./RegisterFormContent.module.scss";
 
 const RegisterFormContent = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterProps>({ resolver: zodResolver(userCreateSchema) });
+
+  const onSubmit = async (data: RegisterProps) => {
+    console.log(data);
+  };
+
+  const onError = (error: FieldErrors<RegisterProps>) => {
+    console.log(error);
+  };
+
   return (
     <>
-      <form action="" className={styles.registerForm}>
+      <form
+        onSubmit={handleSubmit(onSubmit, onError)}
+        className={styles.registerForm}
+      >
         <FormTitle title="新規登録" />
-        <InputForm label="アカウント名" name="name" type="text" />
-        <InputForm label="メールアドレス" name="email" type="text" />
-        <InputForm label="パスワード" name="password" type="password" />
+        <InputForm
+          label="アカウント名"
+          name="name"
+          type="text"
+          register={register("name")}
+          error={errors.name?.message}
+        />
+        <InputForm
+          label="メールアドレス"
+          name="email"
+          type="text"
+          register={register("email")}
+          error={errors.email?.message}
+        />
+        <InputForm
+          label="パスワード"
+          name="password"
+          type="password"
+          register={register("password")}
+          error={errors.password?.message}
+        />
         <InputForm
           label="確認用パスワード"
           name="confirmedPassword"
           type="password"
+          register={register("confirmedPassword")}
+          error={errors.confirmedPassword?.message}
         />
         <div className={styles.buttonContent}>
-          <Button type="submit" label="アカウント登録" variant="primary" />
+          <Button
+            type="submit"
+            label="アカウント登録"
+            variant="primary"
+            disabled={isSubmitting}
+          />
           <Link href="/">
             <Button type="button" label="戻る" variant="secondary" />
           </Link>

--- a/src/components/utils/Button/Button.tsx
+++ b/src/components/utils/Button/Button.tsx
@@ -2,10 +2,21 @@ import type { ButtonProps } from "@/types/utilType";
 import classNames from "classnames";
 import styles from "./Button.module.scss";
 
-const Button = ({ type, label, handleClick, variant }: ButtonProps) => {
+const Button = ({
+  type,
+  label,
+  handleClick,
+  variant,
+  disabled,
+}: ButtonProps) => {
   const buttonClass = classNames(styles.button, styles[variant]);
   return (
-    <button type={type} onClick={handleClick} className={buttonClass}>
+    <button
+      type={type}
+      onClick={handleClick}
+      className={buttonClass}
+      disabled={disabled}
+    >
       {label}
     </button>
   );

--- a/src/lib/validate.ts
+++ b/src/lib/validate.ts
@@ -7,17 +7,25 @@ export const userCreateSchema = z
       .string()
       .min(1, { message: "ユーザー名は必須項目です" })
       .max(20, { message: "ユーザー名は20文字以下にしてください" })
-      .trim(),
+      .refine((val) => val.trim().length > 0 && !/\s/.test(val), {
+        message: "ユーザー名に空白を含めることはできません",
+      }),
     email: z
       .string()
-      .email({ message: "メールアドレスの形式が正しくありません" })
-      .trim(),
+      .email({ message: "メールアドレスの形式が正しくありません" }),
     password: z
       .string()
       .min(6, { message: "パスワードは６文字以上にしてください" })
       .max(20, { message: "パスワードは２０文字以内にしてください" })
-      .trim(),
-    confirmedPassword: z.string().trim(),
+      .refine((val) => val.trim().length > 0 && !/\s/.test(val), {
+        message: "パスワードに空白を含めることはできません",
+      }),
+    confirmedPassword: z
+      .string()
+      .min(1, { message: "確認用パスワードは必須項目です" })
+      .refine((val) => val.trim().length > 0 && !/\s/.test(val), {
+        message: "確認用パスワードに空白を含めることはできません",
+      }),
   })
   .refine((data) => data.password === data.confirmedPassword, {
     message: "パスワードが一致しません",
@@ -28,13 +36,14 @@ export const userCreateSchema = z
 export const userLoginSchema = z.object({
   email: z
     .string()
-    .email({ message: "メールアドレスの形式が正しくありません" })
-    .trim(),
+    .email({ message: "メールアドレスの形式が正しくありません" }),
   password: z
     .string()
     .min(6, { message: "パスワードは６文字以上にしてください" })
     .max(20, { message: "パスワードは２０文字以内にしてください" })
-    .trim(),
+    .refine((val) => val.trim().length > 0 && !/\s/.test(val), {
+      message: "パスワードに空白を含めることはできません",
+    }),
 });
 
 // ユーザー情報編集

--- a/src/types/userType.ts
+++ b/src/types/userType.ts
@@ -1,13 +1,30 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
 // ユーザー関連入力フォームコンポーネント(InputForm)のpropsの型
 export interface InputFormProps {
   label: string;
   name: string;
   type: string;
   error?: string;
+  register: UseFormRegisterReturn;
 }
 
 // ユーザーフォーム　別ページへのリンク表示コンポーネント（NavigationLink）のpropsの型
 export interface NavigationLinkProps {
   url: string;
   navi: string;
+}
+
+// ユーザーフォーム　registerインプット要素の型
+export interface RegisterProps {
+  name: string;
+  email: string;
+  password: string;
+  confirmedPassword: string;
+}
+
+// ユーザーフォーム loginインプット要素の型
+export interface LoginProps {
+  email: string;
+  password: string;
 }

--- a/src/types/utilType.ts
+++ b/src/types/utilType.ts
@@ -3,4 +3,5 @@ export interface ButtonProps {
   type: "button" | "reset" | "submit" | undefined;
   handleClick?: () => void;
   variant: "primary" | "secondary";
+  disabled?: boolean;
 }


### PR DESCRIPTION
## 概要 :bulb:
- アカウント登録フォーム(app/user/register)、ログインフォーム(app/user/login)をReact Hook Formで管理

## 観点 :eye:
#### アカウント登録フォーム(app/user/register)、ログインフォーム(app/user/login)をReact Hook Formで管理
- バリデーションはzodを使用
- バリデーション内容に空白の禁止項目を追加
- フォームの送信中にボタンにdisabeldを追加
- フォームの送信処理はまだ未完成（NextAuth導入時に実装）
<img width="250" alt="スクリーンショット 2024-10-23 23 30 24" src="https://github.com/user-attachments/assets/069e786a-ff14-4175-8e84-7da0bfbee55f">
<img width="250" alt="スクリーンショット 2024-10-23 23 30 34" src="https://github.com/user-attachments/assets/654520d3-c201-46b0-967f-70fe79d2fff5">


## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

## 関連する Issue :memo:

## 補足情報 :notes:

## PR チェックリスト

[PR チェックリスト Wiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
