### PR TITLE
feat: トップページランキングコンテンツ作成　人気新着アルバム表示機能作成

### DIFF
--- a/src/app/api/music/get_album_ranking/route.ts
+++ b/src/app/api/music/get_album_ranking/route.ts
@@ -1,0 +1,41 @@
+import type { AlbumRanking } from "@/types/deezerType";
+import axios from "axios";
+import { type NextRequest, NextResponse } from "next/server";
+
+const deezerUrl = process.env.DEEZER_URL;
+
+export const GET = async (request: NextRequest) => {
+  try {
+    // クエリパラメータから取得する楽曲件数を取得
+    const searchParams = request.nextUrl.searchParams;
+    const limit = searchParams.get("limit");
+
+    // deezerよりアルバムランキング順に取得
+    const songs = await axios.get(`${deezerUrl}/chart/0/albums?limit=${limit}`);
+
+    // deezerよりデータが返らなかった場合
+    if (!songs) {
+      return NextResponse.json({
+        message: "アルバム情報が見つかりませんでした",
+      });
+    }
+
+    const result = songs.data.data.map((song: AlbumRanking) => {
+      return {
+        id: song.id,
+        title: song.title,
+        image: song.cover_big,
+        artist: {
+          id: song.artist.id,
+          name: song.artist.name,
+          image: song.artist.picture_big,
+        },
+      };
+    });
+
+    return NextResponse.json({ result }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーが発生しました" });
+  }
+};

--- a/src/app/api/music/get_artist_ranking/route.ts
+++ b/src/app/api/music/get_artist_ranking/route.ts
@@ -1,0 +1,38 @@
+import type { ArtistRanking } from "@/types/deezerType";
+import axios from "axios";
+import { type NextRequest, NextResponse } from "next/server";
+
+const deezerUrl = process.env.DEEZER_URL;
+
+// アーティストランキングを取得するAPI
+export const GET = async (request: NextRequest) => {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const limit = searchParams.get("limit");
+
+    // deezer apiよりアーティストランキング情報を取得
+    const artist = await axios.get(
+      `${deezerUrl}/chart/0/artists?limit=${limit}`,
+    );
+
+    // アーティスト情報が取得できなかった場合エラー
+    if (!artist) {
+      return NextResponse.json({
+        message: "アーティスト情報が取得できませんでした",
+      });
+    }
+
+    const result = artist.data.data.map((artist: ArtistRanking) => {
+      return {
+        id: artist.id,
+        name: artist.name,
+        image: artist.picture_big,
+      };
+    });
+
+    return NextResponse.json({ result }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラーです" });
+  }
+};

--- a/src/app/api/music/get_favorite_album/route.ts
+++ b/src/app/api/music/get_favorite_album/route.ts
@@ -1,0 +1,43 @@
+import type { FavoriteAlbum } from "@/types/deezerType";
+import axios from "axios";
+import { type NextRequest, NextResponse } from "next/server";
+
+const deezerUrl = process.env.DEEZER_URL;
+
+// 新着人気アルバムを取得する関数
+export const GET = async (request: NextRequest) => {
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const limit = searchParams.get("limit");
+
+    const favoriteAlbum = await axios.get(
+      `${deezerUrl}/editorial/16/releases?limit=${limit}`,
+    );
+
+    // 楽曲情報が取得できなかった場合
+    if (!favoriteAlbum) {
+      return NextResponse.json({
+        message: "人気新着情報が取得できませんでした。",
+      });
+    }
+
+    // レスポンス内容を指定
+    const result = favoriteAlbum.data.data.map((album: FavoriteAlbum) => {
+      return {
+        id: album.id,
+        title: album.title,
+        image: album.cover_big,
+        release_date: album.release_date,
+        artist: {
+          id: album.artist.id,
+          name: album.artist.name,
+        },
+      };
+    });
+
+    return NextResponse.json({ result }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ message: "サーバーエラー" });
+  }
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
 import {
   getAlbumRanking,
   getArtistRanking,
+  getFavoriteAlbum,
   getSingleSongRanking,
 } from "@/utils/api";
 import styles from "./page.module.scss";
@@ -16,6 +17,8 @@ const TopPage = async () => {
   const albums = await getAlbumRanking(4);
   // アーティストランキング4件取得
   const artists = await getArtistRanking(4);
+  // 人気新着アルバム4件取得
+  const favoriteAlbums = await getFavoriteAlbum(4);
 
   return (
     <div className={styles.top__content}>
@@ -47,8 +50,8 @@ const TopPage = async () => {
         <div className={styles.top__content_title}>
           <SongGroupTitle title="人気新着" />
           <SongDetailLink link="/" />
-          {/* 人気新着 */}
         </div>
+        <SongGroup songs={favoriteAlbums} />
       </section>
 
       <section className={styles.top__content_unit}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,22 @@
+import ArtistGroup from "@/components/top/ArtistGroup/ArtistGroup";
 import SongDetailLink from "@/components/top/SongDetailLink/SongDetailLink";
 import SongGroup from "@/components/top/SongGroup/SongGroup";
 import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
-import { getSingleSongRanking } from "@/utils/api";
+import {
+  getAlbumRanking,
+  getArtistRanking,
+  getSingleSongRanking,
+} from "@/utils/api";
 import styles from "./page.module.scss";
 
 const TopPage = async () => {
   // シングルランキング楽曲4件取得
-  const singleSong = await getSingleSongRanking(4);
+  const singleSongs = await getSingleSongRanking(4);
+  // アルバムランキング4件取得
+  const albums = await getAlbumRanking(4);
+  // アーティストランキング4件取得
+  const artists = await getArtistRanking(4);
+
   return (
     <div className={styles.top__content}>
       <section className={styles.top__content_unit}>
@@ -14,23 +24,23 @@ const TopPage = async () => {
           <SongGroupTitle title="シングルランキング" />
           <SongDetailLink link="/" />
         </div>
-        <SongGroup songs={singleSong} />
+        <SongGroup songs={singleSongs} />
       </section>
 
       <section className={styles.top__content_unit}>
         <div className={styles.top__content_title}>
           <SongGroupTitle title="アルバムランキング" />
           <SongDetailLink link="/" />
-          {/* アルバムランキング */}
         </div>
+        <SongGroup songs={albums} />
       </section>
 
       <section className={styles.top__content_unit}>
         <div className={styles.top__content_title}>
           <SongGroupTitle title="アーティストランキング" />
           <SongDetailLink link="/" />
-          {/* アーティストランキング */}
         </div>
+        <ArtistGroup artists={artists} />
       </section>
 
       <section className={styles.top__content_unit}>

--- a/src/components/top/ArtistGroup/ArtistGroup.module.scss
+++ b/src/components/top/ArtistGroup/ArtistGroup.module.scss
@@ -1,0 +1,6 @@
+.content {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  align-items: flex-start;
+  justify-items: center;
+}

--- a/src/components/top/ArtistGroup/ArtistGroup.tsx
+++ b/src/components/top/ArtistGroup/ArtistGroup.tsx
@@ -1,0 +1,22 @@
+import type { ArtistGroupProps } from "@/types/deezerType";
+import ArtistInfo from "../ArtistInfo/ArtistInfo";
+import styles from "./ArtistGroup.module.scss";
+
+const ArtistGroup = ({ artists }: { artists: ArtistGroupProps[] }) => {
+  return (
+    <div className={styles.content}>
+      {artists.map((artist: ArtistGroupProps) => {
+        return (
+          <ArtistInfo
+            key={artist.id}
+            id={artist.id}
+            name={artist.name}
+            image={artist.image}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ArtistGroup;

--- a/src/components/top/ArtistInfo/ArtistInfo.module.scss
+++ b/src/components/top/ArtistInfo/ArtistInfo.module.scss
@@ -10,7 +10,7 @@
   }
 
   & > img {
-    border-radius: 10px;
+    border-radius: 50%;
     box-shadow: 0px 0px 10px -5px #ffffff;
     width: 100%;
     height: 100%;
@@ -23,5 +23,6 @@
   & > p {
     margin-top: 0.3rem;
     font-weight: bold;
+    text-align: center;
   }
 }

--- a/src/components/top/ArtistInfo/ArtistInfo.module.scss
+++ b/src/components/top/ArtistInfo/ArtistInfo.module.scss
@@ -1,0 +1,27 @@
+@import "/src/app/styles/variables.scss";
+
+.content {
+  border-radius: 10px;
+  padding: 0.4rem;
+  transition: background-color 0.3s ease-in-out;
+
+  &:hover {
+    background-color: $hover-back-color;
+  }
+
+  & > img {
+    border-radius: 10px;
+    box-shadow: 0px 0px 10px -5px #ffffff;
+    width: 100%;
+    height: 100%;
+
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+
+  & > p {
+    margin-top: 0.3rem;
+    font-weight: bold;
+  }
+}

--- a/src/components/top/ArtistInfo/ArtistInfo.tsx
+++ b/src/components/top/ArtistInfo/ArtistInfo.tsx
@@ -1,0 +1,28 @@
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./ArtistInfo.module.scss";
+
+const ArtistInfo = ({
+  id,
+  name,
+  image,
+}: {
+  id: number;
+  name: string;
+  image: string;
+}) => {
+  return (
+    <Link href="/" className={styles.content}>
+      <Image
+        src={image}
+        alt={`${image}-${id}の画像`}
+        width={150}
+        height={150}
+        priority
+      />
+      <p>{name}</p>
+    </Link>
+  );
+};
+
+export default ArtistInfo;

--- a/src/types/deezerType.ts
+++ b/src/types/deezerType.ts
@@ -54,6 +54,17 @@ export interface AlbumRanking extends Album {
   artist: Artist;
 }
 
+// 新着人気楽曲取得APIにて使用する型
+export interface FavoriteAlbum extends Album {
+  release_date: "2024-10-30";
+  artist: {
+    id: number;
+    name: string;
+    tracklist: string;
+    type: string;
+  };
+}
+
 export interface SingleSong extends Song {
   artist: Artist;
   album: Album;

--- a/src/types/deezerType.ts
+++ b/src/types/deezerType.ts
@@ -41,8 +41,28 @@ export interface Album {
   type: string;
 }
 
+// アーティストランキング取得APIにて使用する型
+export interface ArtistRanking extends Artist {
+  position: number;
+}
+
+// アルバムランキング取得APIにて使用する型
+export interface AlbumRanking extends Album {
+  link: string;
+  radio: string;
+  position: string;
+  artist: Artist;
+}
+
 export interface SingleSong extends Song {
   artist: Artist;
   album: Album;
   type: string;
+}
+
+// ArtistGroupPropsの型
+export interface ArtistGroupProps {
+  id: number;
+  name: string;
+  image: string;
 }

--- a/src/types/topPageType.ts
+++ b/src/types/topPageType.ts
@@ -2,8 +2,8 @@
 export interface SongGroupProps {
   id: number;
   title: string;
-  duration: number;
-  preview: string;
+  duration?: number;
+  preview?: string;
   image: string;
   artist: {
     id: number;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -12,3 +12,27 @@ export const getSingleSongRanking = async (limit: number) => {
     handleError(error);
   }
 };
+
+// アルバムランキングを取得する関数(limit: 取得件数)
+export const getAlbumRanking = async (limit: number) => {
+  try {
+    const result = await axios.get(
+      `http://localhost:3000/api/music/get_album_ranking?limit=${limit}`,
+    );
+    return result.data.result;
+  } catch (error) {
+    handleError(error);
+  }
+};
+
+// アーティストランキングを取得する関数(limit: 取得件数)
+export const getArtistRanking = async (limit: number) => {
+  try {
+    const result = await axios.get(
+      `http://localhost:3000/api/music/get_artist_ranking?limit=${limit}`,
+    );
+    return result.data.result;
+  } catch (error) {
+    handleError(error);
+  }
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -36,3 +36,15 @@ export const getArtistRanking = async (limit: number) => {
     handleError(error);
   }
 };
+
+// 新着人気アルバムを取得する関数(limit: 取得件数)
+export const getFavoriteAlbum = async (limit: number) => {
+  try {
+    const result = await axios.get(
+      `http://localhost:3000/api/music/get_favorite_album?limit=${limit}`,
+    );
+    return result.data.result;
+  } catch (error) {
+    handleError(error);
+  }
+};


### PR DESCRIPTION
## 概要 :bulb:
- トップページにアルバムランキング、アーティストランキング、新着アルバムを4件ずつ表示
<img width="200" alt="スクリーンショット 2024-11-01 14 47 19" src="https://github.com/user-attachments/assets/11a02aeb-4994-4d1d-8006-6c766bd7ce72">
<img width="200" alt="スクリーンショット 2024-11-01 14 47 34" src="https://github.com/user-attachments/assets/1ff91f67-c8e3-4796-9773-feb1341e0060">


## 観点 :eye:
- アルバムランキングを取得するAPIと関数を作成
- アーティストランキングを取得するAPIと関数を作成
- 新着人気アルバムを取得するAPIと関数を作成
- アーティストランキングを表示するコンポーネントを作成

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

> 実装したテストクラスや実施したテストケース。

## 関連する Issue :memo:

> 関連する Issue へのリンク。

## 補足情報 :notes:

> 補足情報があれば記載。

## PR チェックリスト

[PR チェックリスト Wiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)

