### PR TITLE
ランキング結果ページ(シングル、アルバム、アーティスト)作成

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ const TopPage = async () => {
       <section className={styles.top__content_unit}>
         <div className={styles.top__content_title}>
           <SongGroupTitle title="シングルランキング" />
-          <SongDetailLink link="/" />
+          <SongDetailLink link="/ranking/single" />
         </div>
         <SongGroup songs={singleSongs} />
       </section>
@@ -33,7 +33,7 @@ const TopPage = async () => {
       <section className={styles.top__content_unit}>
         <div className={styles.top__content_title}>
           <SongGroupTitle title="アルバムランキング" />
-          <SongDetailLink link="/" />
+          <SongDetailLink link="/ranking/album" />
         </div>
         <SongGroup songs={albums} />
       </section>
@@ -41,7 +41,7 @@ const TopPage = async () => {
       <section className={styles.top__content_unit}>
         <div className={styles.top__content_title}>
           <SongGroupTitle title="アーティストランキング" />
-          <SongDetailLink link="/" />
+          <SongDetailLink link="/ranking/artist" />
         </div>
         <ArtistGroup artists={artists} />
       </section>

--- a/src/app/ranking/album/page.module.scss
+++ b/src/app/ranking/album/page.module.scss
@@ -1,0 +1,17 @@
+@import "/src/app/styles/variables.scss";
+.content {
+  padding: 1rem 0.3rem;
+
+  &_unit {
+    padding: 1rem;
+    margin: 1rem 0.5rem;
+    background-color: $back-color;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+
+    & > div {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/src/app/ranking/album/page.tsx
+++ b/src/app/ranking/album/page.tsx
@@ -1,0 +1,20 @@
+import SongGroup from "@/components/top/SongGroup/SongGroup";
+import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
+import styles from "./page.module.scss";
+import { getAlbumRanking } from "@/utils/api";
+
+const AlbumPage = async () => {
+  const albums = await getAlbumRanking(20);
+  return (
+    <div className={styles.content}>
+      <div className={styles.content_unit}>
+        <div>
+          <SongGroupTitle title="アルバムランキング" />
+        </div>
+        <SongGroup songs={albums} />
+      </div>
+    </div>
+  );
+};
+
+export default AlbumPage;

--- a/src/app/ranking/album/page.tsx
+++ b/src/app/ranking/album/page.tsx
@@ -1,7 +1,7 @@
 import SongGroup from "@/components/top/SongGroup/SongGroup";
 import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
-import styles from "./page.module.scss";
 import { getAlbumRanking } from "@/utils/api";
+import styles from "./page.module.scss";
 
 const AlbumPage = async () => {
   const albums = await getAlbumRanking(20);

--- a/src/app/ranking/artist/page.module.scss
+++ b/src/app/ranking/artist/page.module.scss
@@ -1,0 +1,17 @@
+@import "/src/app/styles/variables.scss";
+.content {
+  padding: 1rem 0.3rem;
+
+  &_unit {
+    padding: 1rem;
+    margin: 1rem 0.5rem;
+    background-color: $back-color;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+
+    & > div {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/src/app/ranking/artist/page.tsx
+++ b/src/app/ranking/artist/page.tsx
@@ -1,8 +1,8 @@
+import ArtistGroup from "@/components/top/ArtistGroup/ArtistGroup";
 import SongGroup from "@/components/top/SongGroup/SongGroup";
 import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
 import { getArtistRanking } from "@/utils/api";
 import styles from "./page.module.scss";
-import ArtistGroup from "@/components/top/ArtistGroup/ArtistGroup";
 
 const artistRanking = async () => {
   const artists = await getArtistRanking(20);

--- a/src/app/ranking/artist/page.tsx
+++ b/src/app/ranking/artist/page.tsx
@@ -1,0 +1,22 @@
+import SongGroup from "@/components/top/SongGroup/SongGroup";
+import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
+import { getArtistRanking } from "@/utils/api";
+import styles from "./page.module.scss";
+import ArtistGroup from "@/components/top/ArtistGroup/ArtistGroup";
+
+const artistRanking = async () => {
+  const artists = await getArtistRanking(20);
+
+  return (
+    <div className={styles.content}>
+      <div className={styles.content_unit}>
+        <div>
+          <SongGroupTitle title="アーティストランキング" />
+        </div>
+        <ArtistGroup artists={artists} />
+      </div>
+    </div>
+  );
+};
+
+export default artistRanking;

--- a/src/app/ranking/single/page.module.scss
+++ b/src/app/ranking/single/page.module.scss
@@ -1,0 +1,17 @@
+@import "/src/app/styles/variables.scss";
+.content {
+  padding: 1rem 0.3rem;
+
+  &_unit {
+    padding: 1rem;
+    margin: 1rem 0.5rem;
+    background-color: $back-color;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+
+    & > div {
+      margin-bottom: 1rem;
+    }
+  }
+}

--- a/src/app/ranking/single/page.tsx
+++ b/src/app/ranking/single/page.tsx
@@ -1,0 +1,21 @@
+import SongGroup from "@/components/top/SongGroup/SongGroup";
+import SongGroupTitle from "@/components/top/SongGroupTitle/SongGroupTitle";
+import { getSingleSongRanking } from "@/utils/api";
+import styles from "./page.module.scss";
+
+const singleRanking = async () => {
+  const singles = await getSingleSongRanking(20);
+
+  return (
+    <div className={styles.content}>
+      <div className={styles.content_unit}>
+        <div>
+          <SongGroupTitle title="シングルランキング" />
+        </div>
+        <SongGroup songs={singles} />
+      </div>
+    </div>
+  );
+};
+
+export default singleRanking;

--- a/src/components/Header/Hamburger/Hamburger.module.scss
+++ b/src/components/Header/Hamburger/Hamburger.module.scss
@@ -57,7 +57,7 @@
 
       li {
         padding: 20px;
-        font-size: 1rem;
+        font-size: 0.8rem;
         color: $font-main-color;
         cursor: pointer;
 

--- a/src/components/Header/Hamburger/Hamburger.tsx
+++ b/src/components/Header/Hamburger/Hamburger.tsx
@@ -64,10 +64,16 @@ const Hamburger = () => {
             <Link href="/">マイページ</Link>
           </li>
           <li>
-            <Link href="/">人気新着</Link>
+            <Link href="/ranking/single">シングルランキング</Link>
           </li>
           <li>
-            <Link href="/">シングルランキング</Link>
+            <Link href="/ranking/album">アルバムランキング</Link>
+          </li>
+          <li>
+            <Link href="/ranking/artist">アーティストランキング</Link>
+          </li>
+          <li>
+            <Link href="/">人気新着</Link>
           </li>
           <li>
             <Link href="/">ジャンル一覧</Link>

--- a/src/components/top/ArtistGroup/ArtistGroup.module.scss
+++ b/src/components/top/ArtistGroup/ArtistGroup.module.scss
@@ -3,4 +3,28 @@
   grid-template-columns: repeat(2, 1fr);
   align-items: flex-start;
   justify-items: center;
+
+  & > a:nth-child(1) > img {
+    border: 5px solid gold;
+  }
+
+  & > a:nth-child(2) > img {
+    border: 5px solid silver;
+  }
+
+  & > a:nth-child(3) > img {
+    border: 5px solid rgba(218, 58, 58);
+  }
+
+  & > a:nth-child(1) > p:first-child {
+    color: gold;
+  }
+
+  & > a:nth-child(2) > p:first-child {
+    color: silver;
+  }
+
+  & > a:nth-child(3) > p:first-child {
+    color: rgba(218, 58, 58);
+  }
 }

--- a/src/components/top/ArtistGroup/ArtistGroup.tsx
+++ b/src/components/top/ArtistGroup/ArtistGroup.tsx
@@ -5,13 +5,14 @@ import styles from "./ArtistGroup.module.scss";
 const ArtistGroup = ({ artists }: { artists: ArtistGroupProps[] }) => {
   return (
     <div className={styles.content}>
-      {artists.map((artist: ArtistGroupProps) => {
+      {artists.map((artist: ArtistGroupProps, index) => {
         return (
           <ArtistInfo
             key={artist.id}
             id={artist.id}
             name={artist.name}
             image={artist.image}
+            num={index + 1}
           />
         );
       })}

--- a/src/components/top/ArtistInfo/ArtistInfo.module.scss
+++ b/src/components/top/ArtistInfo/ArtistInfo.module.scss
@@ -9,6 +9,17 @@
     background-color: $hover-back-color;
   }
 
+  &_item {
+    text-align: start;
+    font-weight: bold;
+
+    &__name {
+      text-align: center;
+      font-weight: bold;
+      margin-top: 0.3rem;
+    }
+  }
+
   & > img {
     border-radius: 50%;
     box-shadow: 0px 0px 10px -5px #ffffff;
@@ -18,11 +29,5 @@
     &:hover {
       opacity: 0.8;
     }
-  }
-
-  & > p {
-    margin-top: 0.3rem;
-    font-weight: bold;
-    text-align: center;
   }
 }

--- a/src/components/top/ArtistInfo/ArtistInfo.tsx
+++ b/src/components/top/ArtistInfo/ArtistInfo.tsx
@@ -6,13 +6,16 @@ const ArtistInfo = ({
   id,
   name,
   image,
+  num,
 }: {
   id: number;
   name: string;
   image: string;
+  num: number;
 }) => {
   return (
     <Link href="/" className={styles.content}>
+      <p className={styles.content_item}>Rank&nbsp;{num}</p>
       <Image
         src={image}
         alt={`${image}-${id}の画像`}
@@ -20,7 +23,7 @@ const ArtistInfo = ({
         height={150}
         priority
       />
-      <p>{name}</p>
+      <p className={styles.content_item__name}>{name}</p>
     </Link>
   );
 };

--- a/src/components/top/SongGroup/SongGroup.module.scss
+++ b/src/components/top/SongGroup/SongGroup.module.scss
@@ -3,4 +3,28 @@
   grid-template-columns: repeat(2, 1fr);
   align-items: flex-start;
   justify-items: center;
+
+  & > a:nth-child(1) > img {
+    border: 5px solid gold;
+  }
+
+  & > a:nth-child(2) > img {
+    border: 5px solid silver;
+  }
+
+  & > a:nth-child(3) > img {
+    border: 5px solid rgba(218, 58, 58);
+  }
+
+  & > a:nth-child(1) > p {
+    color: gold;
+  }
+
+  & > a:nth-child(2) > p {
+    color: silver;
+  }
+
+  & > a:nth-child(3) > p {
+    color: rgba(218, 58, 58);
+  }
 }

--- a/src/components/top/SongGroup/SongGroup.tsx
+++ b/src/components/top/SongGroup/SongGroup.tsx
@@ -2,16 +2,17 @@ import type { SongGroupProps } from "@/types/topPageType";
 import SongInfo from "../SongInfo/SonInfo";
 import styles from "./SongGroup.module.scss";
 
-// トップページにて4曲楽曲を表示するコンポーネント
+// 楽曲概要を表示するコンポーネント
 const SongGroup = ({ songs }: { songs: SongGroupProps[] }) => {
   return (
     <>
       <div className={styles.group}>
-        {songs.map((song) => {
+        {songs.map((song, index) => {
           return (
             <SongInfo
               key={song.id}
               id={song.id}
+              num={index + 1}
               title={song.title}
               artist={song.artist.name}
               image={song.image}

--- a/src/components/top/SongInfo/SonInfo.tsx
+++ b/src/components/top/SongInfo/SonInfo.tsx
@@ -3,9 +3,10 @@ import Image from "next/image";
 import Link from "next/link";
 import styles from "./SongInfo.module.scss";
 
-const SongInfo = ({ id, title, artist, image }: SongInfoProps) => {
+const SongInfo = ({ id, num, title, artist, image }: SongInfoProps) => {
   return (
     <Link href="/" className={styles.content}>
+      <p>Rank&nbsp;{num}</p>
       <Image
         src={image}
         alt={`${title}-${id}の画像`}

--- a/src/components/top/SongInfo/SongInfo.module.scss
+++ b/src/components/top/SongInfo/SongInfo.module.scss
@@ -9,6 +9,11 @@
     background-color: $hover-back-color;
   }
 
+  & > p {
+    font-weight: bold;
+    margin-top: 1rem;
+  }
+
   & > img {
     border-radius: 10px;
     box-shadow: 0px 0px 10px -5px #ffffff;

--- a/src/types/topPageType.ts
+++ b/src/types/topPageType.ts
@@ -15,6 +15,7 @@ export interface SongGroupProps {
 // SongInfoコンポーネントの型
 export interface SongInfoProps {
   id: number;
+  num: number;
   title: string;
   image: string;
   artist: string;


### PR DESCRIPTION
## 概要 :bulb:
- シングル、アルバム、アーティストランキング結果ページ作成
<img width="250" alt="スクリーンショット 2024-11-02 0 20 40" src="https://github.com/user-attachments/assets/cb6f0cf5-eadd-4aa8-8795-1bd4675b5d6a">
<img width="250" alt="スクリーンショット 2024-11-02 0 21 09" src="https://github.com/user-attachments/assets/f6706dd7-5004-43b4-95b2-138ce1df45ee">



## 観点 :eye:
- /ranking/single /ranking/album  /ranking/artistにランキングページ作成
- １、２、３位の画像の枠に色を追加

## セキュリティ :key:

ソースコードに対して、以下のチェックを実施する。

- [ ] 特定の個人・団体名などを使用していないか
- [ ] 接続情報など秘密情報が含まれていないか
- [ ] ログに個人情報等が含まれていないか
- [ ] ドメインは example.com を使用しているか

## テスト :test_tube:

## 関連する Issue :memo:

## 補足情報 :notes:

## PR チェックリスト

[PR チェックリスト Wiki](https://github.com/y4edd/sonic-journey/wiki/%E3%83%97%E3%83%AB%E3%83%AA%E3%82%AF%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%83%AA%E3%82%B9%E3%83%88)
